### PR TITLE
Add support for GIF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,9 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# Default Python output image
+out.jpg
+
+# Go executable
+slack/src/faceswapbot/faceswapbot

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Hammertime!
 ### Python stuff
 
 1. Install Python 3.6 (or later)
-2. Install OpenCV:
+2. Install OpenCV (and optionally imageio to support GIF):
 
    ```
-   pip3 install opencv-python
+   pip3 install opencv-python imageio
    ```
 
 

--- a/face_replace/face_replace.py
+++ b/face_replace/face_replace.py
@@ -99,15 +99,32 @@ def random_flip(image):
     return image
 
 
-def show_image(image, show=False):
-    if show:
-        cv2.imshow('img', image)
-        cv2.waitKey(0)
-        cv2.destroyAllWindows()
+def show_image(image):
+    cv2.imshow('img', image)
+    cv2.waitKey(0)
+    cv2.destroyAllWindows()
+
+
+def open_image(infile):
+    if infile.endswith(".gif"):
+        #  No native GIF support in Open CV
+        import imageio
+        gif = imageio.mimread(infile)
+        print("GIF frames: {}".format(len(gif)))
+
+        # Convert form RGB to BGR
+        imgs = [cv2.cvtColor(img, cv2.COLOR_RGB2BGR) for img in gif]
+
+        # Take the first frame
+        img = imgs[0]
+    else:
+        img = cv2.imread(infile)
+
+    return img
 
 
 def photobomb(infile, in_bodies, outfile, show=False):
-    l_img = cv2.imread(infile)
+    l_img = open_image(infile)
 
     body_paths = image_paths(in_bodies)
 
@@ -137,7 +154,8 @@ def photobomb(infile, in_bodies, outfile, show=False):
 
     l_img = paste_image(l_img, s_img, x1, y1, x2, y2)
 
-    show_image(l_img, show)
+    if show:
+        show_image(l_img)
 
     cv2.imwrite(outfile, l_img)
 
@@ -152,7 +170,8 @@ def detect(infile, in_faces, outfile, face_cascade_path, eye_cascade_path,
 
     face_cascade = cv2.CascadeClassifier(face_cascade_path)
     eye_cascade = cv2.CascadeClassifier(eye_cascade_path)
-    l_img = cv2.imread(infile)
+    l_img = open_image(infile)
+
     gray = cv2.cvtColor(l_img, cv2.COLOR_BGR2GRAY)
 
     faces = face_cascade.detectMultiScale(gray, 1.3, 5)
@@ -206,7 +225,8 @@ def detect(infile, in_faces, outfile, face_cascade_path, eye_cascade_path,
         print("No faces detected")
         return False
 
-    show_image(l_img, show)
+    if show:
+        show_image(l_img)
 
     cv2.imwrite(outfile, l_img)
     return True

--- a/face_replace/face_replace.py
+++ b/face_replace/face_replace.py
@@ -112,11 +112,8 @@ def open_image(infile):
         gif = imageio.mimread(infile)
         print("GIF frames: {}".format(len(gif)))
 
-        # Convert form RGB to BGR
-        imgs = [cv2.cvtColor(img, cv2.COLOR_RGB2BGR) for img in gif]
-
-        # Take the first frame
-        img = imgs[0]
+        # Convert first frame form RGB to BGR
+        img = cv2.cvtColor(gif[0], cv2.COLOR_RGB2BGR)
     else:
         img = cv2.imread(infile)
 


### PR DESCRIPTION
Fixes #29.

OpenCV doesn't have GIF support built in.

For GIF images, open them using imageio and convert to a format usable by OpenCV.

Install that library on the server using:
```
pip3 install imageio
```